### PR TITLE
Added record struct and switch expression snippet, added a placeholder name for records

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ propr
 pum
 pvm
 record
+recordd
+records
+recordsd
+recordsr
 singleton
 singletonl
 singletonts

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ singletonl
 singletonts
 struct
 switch
+switche
 tls
 todo
 try

--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -388,35 +388,35 @@
 	"Creates a record type":{
 		"prefix": "record",
 		"body": [
-			"public record Person(${1:string} ${2:Name});"
+			"public record ${1:MyRecord}(${2:string} ${3:Name});"
 			],
 		"description": "Creates a record type"
 	},
 	"Creates a record struct type":{
 		"prefix": "records",
 		"body": [
-			"public record struct Person(${1:string} ${2:Name});"
+			"public record struct ${1:MyRecord}(${2:string} ${3:Name});"
 			],
 		"description": "Creates a record struct type"
 	},
 	"Creates a readonly record struct type":{
 		"prefix": "recordsr",
 		"body": [
-			"public readonly record struct Person(${1:string} ${2:Name});"
+			"public readonly record struct ${1:MyRecord}(${2:string} ${3:Name});"
 			],
 		"description": "Creates a readonly record struct type"
 	},
 	"Creates a record type with deconstructor":{
 		"prefix": "recordd",
 		"body": [
-			"public record Person",
+			"public record ${1:MyRecord}",
 			"{",
-			"\tpublic Person(${1:string} ${2:name}, ${3:int} ${4:age}) => (${5:Name}, ${6:Age}) = ($2, $4);",
+			"\tpublic ${1:MyRecord}(${2:string} ${3:name}, ${4:int} ${5:age}) => (${6:Name}, ${7:Age}) = ($3, $5);",
 			"",
-			"\tpublic $1 $5 { get; set; }",
-			"\tpublic $3 $6 { get; set; }",
+			"\tpublic $2 $6 { get; set; }",
+			"\tpublic $4 $7 { get; set; }",
 			"",
-			"public void Deconstructor(out $1 $2, out $3 $4) => ($2, $4) = ($5, $6);",
+			"public void Deconstructor(out $2 $3, out $4 $5) => ($3, $5) = ($6, $7);",
 			"}"
 			],
 		"description": "Creates a record type with deconstructor"
@@ -424,17 +424,17 @@
 	"Creates a record struct type with deconstructor":{
 		"prefix": "recordsd",
 		"body": [
-			"public record struct Person",
+			"public record struct ${1:MyRecord}",
 			"{",
-			"\tpublic Person(${1:string} ${2:name}, ${3:int} ${4:age}) => (${5:Name}, ${6:Age}) = ($2, $4);",
+			"\tpublic ${1:MyRecord}(${2:string} ${3:name}, ${4:int} ${5:age}) => (${6:Name}, ${7:Age}) = ($3, $5);",
 			"",
-			"\tpublic $1 $5 { get; set; }",
-			"\tpublic $3 $6 { get; set; }",
+			"\tpublic $2 $6 { get; set; }",
+			"\tpublic $4 $7 { get; set; }",
 			"",
-			"public void Deconstructor(out $1 $2, out $3 $4) => ($2, $4) = ($5, $6);",
+			"public void Deconstructor(out $2 $3, out $4 $5) => ($3, $5) = ($6, $7);",
 			"}"
 			],
-		"description": "Creates a record type with deconstructor"
+		"description": "Creates a record struct type with deconstructor"
 	},
 	"Creates a singleton class": {
 		"prefix": "singleton",

--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -493,6 +493,18 @@
 			],
 		"description": "Creates a switch statement"
 	},
+	"Creates a switch expression": {
+		"prefix": "switche",
+		"body": [
+		  "${1:value} switch",
+		  "{",
+		  "\t${2:value1} => ${3:value2},",
+		  "\t_ => default,",
+		  "};",
+		  "$0"
+		],
+		"description": "Creates a switch expression"
+	},
 	"Creates a C# 9 top-level statement": {
 		"prefix": "tls",
 		"body": [

--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -392,10 +392,39 @@
 			],
 		"description": "Creates a record type"
 	},
+	"Creates a record struct type":{
+		"prefix": "records",
+		"body": [
+			"public record struct Person(${1:string} ${2:Name});"
+			],
+		"description": "Creates a record struct type"
+	},
+	"Creates a readonly record struct type":{
+		"prefix": "recordsr",
+		"body": [
+			"public readonly record struct Person(${1:string} ${2:Name});"
+			],
+		"description": "Creates a readonly record struct type"
+	},
 	"Creates a record type with deconstructor":{
 		"prefix": "recordd",
 		"body": [
 			"public record Person",
+			"{",
+			"\tpublic Person(${1:string} ${2:name}, ${3:int} ${4:age}) => (${5:Name}, ${6:Age}) = ($2, $4);",
+			"",
+			"\tpublic $1 $5 { get; set; }",
+			"\tpublic $3 $6 { get; set; }",
+			"",
+			"public void Deconstructor(out $1 $2, out $3 $4) => ($2, $4) = ($5, $6);",
+			"}"
+			],
+		"description": "Creates a record type with deconstructor"
+	},
+	"Creates a record struct type with deconstructor":{
+		"prefix": "recordsd",
+		"body": [
+			"public record struct Person",
 			"{",
 			"\tpublic Person(${1:string} ${2:name}, ${3:int} ${4:age}) => (${5:Name}, ${6:Age}) = ($2, $4);",
 			"",

--- a/snippets/csharp.json
+++ b/snippets/csharp.json
@@ -416,7 +416,7 @@
 			"\tpublic $2 $6 { get; set; }",
 			"\tpublic $4 $7 { get; set; }",
 			"",
-			"public void Deconstructor(out $2 $3, out $4 $5) => ($3, $5) = ($6, $7);",
+			"\tpublic void Deconstructor(out $2 $3, out $4 $5) => ($3, $5) = ($6, $7);",
 			"}"
 			],
 		"description": "Creates a record type with deconstructor"
@@ -431,7 +431,7 @@
 			"\tpublic $2 $6 { get; set; }",
 			"\tpublic $4 $7 { get; set; }",
 			"",
-			"public void Deconstructor(out $2 $3, out $4 $5) => ($3, $5) = ($6, $7);",
+			"\tpublic void Deconstructor(out $2 $3, out $4 $5) => ($3, $5) = ($6, $7);",
 			"}"
 			],
 		"description": "Creates a record struct type with deconstructor"


### PR DESCRIPTION
## Record struct snippets
Added snippets:
### `records` - Mutable positional record struct
``` C#
public record struct MyRecord(string Name);
```
### `recordsd` - Mutable struct record with deconstructor
```C#
public record struct MyRecord
{
    public MyRecord(string name, int age) => (Name, Age) = (name, age);

    public string Name { get; set; }
    public int Age { get; set; }

    public void Deconstructor(out string name, out int age) => (name, age) = (Name, Age);
}
```
### `recordsr` - Immutable positional record struct
```C#
public readonly record struct MyRecord(string Name);
```

## Record changes
Changed the default type name for records from `Person` to a placeholder with the default text `MyRecord`. This should keep records inline with class and struct snippets. I'm not sure if this would be considered a breaking change as its adding another placeholder and may break muscle memory for users.

## Switch expression snippet
Added a snippet for switch expressions from C# 8.0. 
## `switche` - Switch expression
```C#
value switch
{
    value1 => value2,
    _ => default,
};
```
### Realigned the deconstructor for `recordd` and `recordsd`
From:
``` C#
    ...
    public int Age { get; set; }

public void Deconstructor(out string name, out int age) => (name, age) = (Name, Age);
}
```

```C#
    ...
    public int Age { get; set; }

    public void Deconstructor(out string name, out int age) => (name, age) = (Name, Age);
}
```